### PR TITLE
Improve SSH rules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 rules: []
 limit_ssh: false
+openssh_port: 22

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 rules: []
+limit_ssh: false

--- a/environment.ci.yml
+++ b/environment.ci.yml
@@ -3,7 +3,7 @@ name: ansible-ufw
 channels:
   - conda-forge
 dependencies:
-  - python~=3.12
+  - python~=3.12.0
   - pip>=22.2
   - pip:
       - -r requirements.txt

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,4 +17,5 @@
   roles:
     - role: genlab.ufw
       disable_ipv6: true
+      limit_ssh: true
       rules: "{{ custom_rules }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,11 @@
     proto: any
     policy: allow
 
-- name: "Allow rate-limited SSH access"
+- name: "Allow SSH access"
   notify: Reload-ufw
   community.general.ufw:
-    rule: limit
     port: ssh
+    rule: "{{ limit_ssh | ternary('limit', 'allow') }}"
     proto: tcp
 
 - name: "Set whitelist rules"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
 - name: "Allow SSH access"
   notify: Reload-ufw
   community.general.ufw:
-    port: ssh
     rule: "{{ limit_ssh | ternary('limit', 'allow') }}"
+    port: "{{ openssh_port }}"
     proto: tcp
 
 - name: "Set whitelist rules"


### PR DESCRIPTION
- **Do not rate-limit SSH traffic by default (since it breaks Ansible)**
- **As SSH is always allowed by this role, make its port configurable**
- **Fix the Python version pin debacle**
